### PR TITLE
all: Implements gossip based on pull only

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Packet type (1 byte) <br>
 > 1: PullRequest <br>
 > 2: PullResponse <br>
 
+### Packet handle
+<b>PullRequest</b> - It replies a packet to the requester. However, packets that have already been taken by the requester are excluded. <br>
+<b>PullResponse</b> - Stores the received message in memory. Messages that have already been received will be ignored. <br>
+
 
 ## Transport/Security layer
 Transport layer supports peer-to-peer UDP communication.

--- a/broadcast.go
+++ b/broadcast.go
@@ -6,6 +6,11 @@ import (
 )
 
 const (
+	// timeout stands for deletion time of message.
+	//
+	// message is not deleted exactly every timeout reached.
+	// Since the delete loop also runs once every timeout.
+	// So the minimum is timeout, the maximum is 2*timeout.
 	timeout = 30 * time.Second
 )
 

--- a/broadcast.go
+++ b/broadcast.go
@@ -1,0 +1,89 @@
+package gogossip
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	//
+	timeout = 30 * time.Second
+)
+
+type message struct {
+	value    []byte
+	deadline time.Time
+
+	// Marking for the requestor. Exclude if the requestor has already taken it.
+	touched map[string]bool
+}
+
+type broadcast struct {
+	mu sync.Mutex
+	m  map[[8]byte]message
+}
+
+func (b *broadcast) add(key [8]byte, value []byte) bool {
+	b.mu.Lock()
+	if _, ok := b.m[key]; ok {
+		// already received
+		b.mu.Unlock()
+		return false
+	}
+	b.m[key] = message{
+		value:    value,
+		deadline: time.Now().Add(timeout),
+		touched:  make(map[string]bool),
+	}
+	b.mu.Unlock()
+
+	return true
+}
+
+// The caller must hold b.mu.
+func (b *broadcast) keys() [][8]byte {
+	keys := make([][8]byte, 0, len(b.m))
+	for k := range b.m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func (b *broadcast) itemsWithTouch(addr string) ([][8]byte, [][]byte) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	keys := b.keys()
+
+	rk := make([][8]byte, 0, len(keys))
+	rv := make([][]byte, 0, len(keys))
+
+	for k, v := range b.m {
+		if !v.touched[addr] {
+			rk = append(rk, k)
+			rv = append(rv, v.value)
+		}
+		v.touched[addr] = true
+	}
+	return rk, rv
+}
+
+func (b *broadcast) timeoutLoop() {
+	ticker := time.NewTicker(timeout)
+	defer ticker.Stop()
+	for {
+		<-ticker.C
+
+		now := time.Now()
+		b.mu.Lock()
+		keys := b.keys()
+		for _, key := range keys {
+			if _, ok := b.m[key]; !ok {
+				return
+			}
+			if b.m[key].deadline.Before(now) {
+				delete(b.m, key)
+			}
+		}
+		b.mu.Unlock()
+	}
+}

--- a/gossip.go
+++ b/gossip.go
@@ -1,7 +1,7 @@
 package gogossip
 
 import (
-	"fmt"
+	"log"
 	"math/rand"
 	"sync/atomic"
 	"time"
@@ -67,7 +67,7 @@ func (g *Gossiper) pullLoop() {
 		// Encryption.
 		buf, err := EncryptPacket(g.cfg.encryptType, g.cfg.passphrase, msg)
 		if err != nil {
-			fmt.Println("pullLoop: ", err)
+			log.Printf("pullLoop: encryption failure %v", err)
 			continue
 		}
 
@@ -85,7 +85,7 @@ func (g *Gossiper) readLoop() {
 		buf := make([]byte, 8192)
 		n, sender, err := g.transport.ReadFromUDP(buf)
 		if err != nil {
-			fmt.Println("readLoop: ", err)
+			log.Printf("readLoop: read UDP packet failure %v", err)
 			continue
 		}
 

--- a/gossip.go
+++ b/gossip.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	//
-	gossipNumber = 3
+	gossipNumber = 2
 	//
 	pullInterval = 200 * time.Millisecond
 )

--- a/gossip.go
+++ b/gossip.go
@@ -72,7 +72,10 @@ func (g *Gossiper) pullLoop() {
 		}
 
 		// Labeling.
-		p := BytesToLabel([]byte{msg.Kind(), byte(g.cfg.encryptType)}).combine(buf)
+		p, err := bytesToLabel([]byte{msg.Kind(), byte(g.cfg.encryptType)}).combine(buf)
+		if err != nil {
+			log.Printf("pullLoop: labeling failure %v", err)
+		}
 
 		// Choose random peers and send.
 		multicastWithRawAddress(g.transport, g.selectRandomPeers(gossipNumber), p)

--- a/gossip.go
+++ b/gossip.go
@@ -75,6 +75,7 @@ func (g *Gossiper) pullLoop() {
 		p, err := bytesToLabel([]byte{msg.Kind(), byte(g.cfg.encryptType)}).combine(buf)
 		if err != nil {
 			log.Printf("pullLoop: labeling failure %v", err)
+			continue
 		}
 
 		// Choose random peers and send.

--- a/handler.go
+++ b/handler.go
@@ -8,7 +8,11 @@ import (
 )
 
 func (g *Gossiper) handler(buf []byte, sender *net.UDPAddr) {
-	label, payload := SplitLabel(buf)
+	label, payload, err := splitLabel(buf)
+	if err != nil {
+		log.Printf("handler: SplitLabel failure, %v", err)
+	}
+
 	encType := EncryptType(label.encryptType)
 
 	plain, err := DecryptPayload(encType, g.cfg.passphrase, payload)
@@ -25,7 +29,10 @@ func (g *Gossiper) handler(buf []byte, sender *net.UDPAddr) {
 				log.Printf("handler: encryption failure, %v", err)
 				return
 			}
-			p := BytesToLabel([]byte{packet.Kind(), byte(encType)}).combine(cipher)
+			p, err := bytesToLabel([]byte{packet.Kind(), byte(encType)}).combine(cipher)
+			if err != nil {
+				log.Printf("handler: trasport failture, %v", err)
+			}
 			if _, err := g.transport.WriteToUDP(p, sender); err != nil {
 				log.Printf("handler: transport filaure, %v", err)
 				return

--- a/handler.go
+++ b/handler.go
@@ -11,12 +11,14 @@ func (g *Gossiper) handler(buf []byte, sender *net.UDPAddr) {
 	label, payload, err := splitLabel(buf)
 	if err != nil {
 		log.Printf("handler: SplitLabel failure, %v", err)
+		return
 	}
 
 	encType := EncryptType(label.encryptType)
 
 	plain, err := DecryptPayload(encType, g.cfg.passphrase, payload)
 	if err != nil {
+		log.Printf("handler: decryption failure, %v", err)
 		return
 	}
 
@@ -32,6 +34,7 @@ func (g *Gossiper) handler(buf []byte, sender *net.UDPAddr) {
 			p, err := bytesToLabel([]byte{packet.Kind(), byte(encType)}).combine(cipher)
 			if err != nil {
 				log.Printf("handler: trasport failture, %v", err)
+				return
 			}
 			if _, err := g.transport.WriteToUDP(p, sender); err != nil {
 				log.Printf("handler: transport filaure, %v", err)

--- a/handler.go
+++ b/handler.go
@@ -50,6 +50,8 @@ func (g *Gossiper) pullRequestHandle(payload []byte, enctype EncryptType, sender
 		return nil
 	}
 
+	// TODO(dbadoy): Send it in multiple pieces. Sometimes occur error
+	// about message too big.
 	return &PullResponse{atomic.AddUint32(&g.seq, 1), kl, vl}
 }
 

--- a/label.go
+++ b/label.go
@@ -2,28 +2,36 @@ package gogossip
 
 import (
 	"encoding/binary"
+	"errors"
 	"math/rand"
 	"time"
 )
 
+var (
+	errTooShort = errors.New("bytes too short")
+)
+
 // Label: packetType(1 byte) + encryptType(1 byte)
 
-var labelTotalSize = binary.Size(Label{})
+var labelTotalSize = binary.Size(label{})
 
-type Label struct {
+type label struct {
 	packetType  byte
 	encryptType byte
 	// tempSize    [4]byte
 }
 
-func (l Label) combine(buf []byte) []byte {
+func (l label) combine(buf []byte) ([]byte, error) {
+	if binary.Size(l) != labelTotalSize {
+		return nil, errTooShort
+	}
 	b := make([]byte, 0, labelTotalSize+len(buf))
 	b = append(b, l.bytes()...)
 	b = append(b, buf...)
-	return b
+	return b, nil
 }
 
-func (l Label) bytes() []byte {
+func (l label) bytes() []byte {
 	b := make([]byte, labelTotalSize)
 	b[0] = l.packetType
 	b[1] = l.encryptType
@@ -31,23 +39,23 @@ func (l Label) bytes() []byte {
 	return b
 }
 
-func BytesToLabel(buf []byte) Label {
+func bytesToLabel(buf []byte) *label {
 	if len(buf) != labelTotalSize {
-		panic("hi")
+		return nil
 	}
 	// var tempSize [4]byte
 	// copy(tempSize[:], buf[2:4])
 
-	return Label{
+	return &label{
 		buf[0], buf[1], // tempSize,
 	}
 }
 
-func SplitLabel(buf []byte) (Label, []byte) {
+func splitLabel(buf []byte) (*label, []byte, error) {
 	if len(buf) < labelTotalSize {
-		panic("hi")
+		return nil, nil, errTooShort
 	}
-	return BytesToLabel(buf[:labelTotalSize]), buf[labelTotalSize:]
+	return bytesToLabel(buf[:labelTotalSize]), buf[labelTotalSize:], nil
 }
 
 func idGenerator() [8]byte {

--- a/message.go
+++ b/message.go
@@ -6,11 +6,8 @@ type Packet interface {
 }
 
 const (
-	PushMessageType  = 0x01
-	PushAckType      = 0x02
-	PullSyncType     = 0x03
-	PullRequestType  = 0x04
-	PullResponseType = 0x05
+	PullRequestType  = 0x01
+	PullResponseType = 0x02
 )
 
 type (

--- a/message.go
+++ b/message.go
@@ -14,38 +14,15 @@ const (
 )
 
 type (
-	PushMessage struct {
-		id   uint32
-		Key  [8]byte
-		Data []byte
-	}
-	PushAck struct {
-		id  uint32
-		Key [8]byte
-	}
-	PullSync struct {
-		id     uint32
-		Target [8]byte
-	}
 	PullRequest struct {
-		id     uint32
-		Target [8]byte
+		id uint32
 	}
 	PullResponse struct {
 		id     uint32
-		Target [8]byte
-		Data   []byte
+		Keys   [][8]byte
+		Values [][]byte
 	}
 )
-
-func (p *PushMessage) ID() uint32 { return p.id }
-func (p *PushMessage) Kind() byte { return PullRequestType }
-
-func (p *PushAck) ID() uint32 { return p.id }
-func (p *PushAck) Kind() byte { return PullRequestType }
-
-func (p *PullSync) ID() uint32 { return p.id }
-func (p *PullSync) Kind() byte { return PullRequestType }
 
 func (req *PullRequest) ID() uint32 { return req.id }
 func (req *PullRequest) Kind() byte { return PullRequestType }

--- a/utils/static_peer.go
+++ b/utils/static_peer.go
@@ -1,25 +1,46 @@
 package utils
 
+import "sync"
+
 type StaticPeers map[string]string
 
-type RegistryGossip map[string]string
+type RegistryGossip struct {
+	mu sync.Mutex
+	m  map[string]string
+}
+
+func NewRegistryGossip() RegistryGossip {
+	return RegistryGossip{
+		m: make(map[string]string),
+	}
+}
 
 func (r *RegistryGossip) Register(k, v string) {
-	(*r)[k] = v
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.m[k] = v
 }
 
 func (r *RegistryGossip) Deregister(k string) {
-	delete((*r), k)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.m, k)
 }
 
 func (r *RegistryGossip) Gossipiers() []string {
-	res := make([]string, len(*r))
-	for _, raw := range *r {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	res := make([]string, 0, len(r.m))
+	for _, raw := range r.m {
 		res = append(res, raw)
 	}
 	return res
 }
 
 func (r *RegistryGossip) Size() int {
-	return len(*r)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return len(r.m)
 }


### PR DESCRIPTION
There is no evidence that the previously envisioned method is better, and the ACK and SYN processes are more likely to occur, increasing network congestion. It is also fatal that if more requests come in than the LRU cache, the message is discarded and cannot be delivered to other nodes. (as a result of rough testing, I found that messages were not spread evenly and were dropped)
Implement the logic to convert the pull method and store the message to be delivered to other nodes in memory.
There are still problems to be solved. For example, there are issues such as what size the pipe that transmits data to the application should be, and when sending a response to a pull request, if the size is too large, It need to split the packet and send it.

